### PR TITLE
Exclude example from builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-walk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "iteratively walk a DOM node",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
@@ -20,6 +20,7 @@
   "devDependencies": {
     "browserify-server": "~0.5.6"
   },
+  "files": [],
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Taken from the `package.json` [documentation](https://docs.npmjs.com/files/package.json)

> The optional `files` field is an array of file patterns that describes the entries to be included when your package is installed as a dependency.

The `example` directory of this project is not explicitly excluded anywhere so it seems it gets included inside the build of all projects that use `dom-walk` as a dependency.

I set `files` to an empty array because certain files are included no matter what the `files` whitelist says (see documentation for full list). I will list the files in this project that should be included along with the rule that shows why we don't need it explicitly.

- `package.json` (special file that is always included)
- `index.js` (contents of `main` in `package.json` is always included)
- `README.md` (special file that is always included)
- `LICENCE` (special file that is always included)